### PR TITLE
Prevent workflow run on push to feature branches

### DIFF
--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -9,7 +9,6 @@ on:
     branches:
     - master
     - develop
-    - feature/*
     - release/*
     - hotfix/*
   pull_request:


### PR DESCRIPTION
It makes more sense to run he workflow when a PR is raised rather than when the feature branch is pushed.

Closes #41